### PR TITLE
feat: add dark mode toggle to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,8 +54,9 @@
     background: url("images/beijing.png") no-repeat center fixed;
     background-size: cover;
     font-family: "Segoe UI", "Roboto", sans-serif;
-    color: #fff;
+    color: #1f2933;
     overflow-x: hidden;
+    transition: background 0.4s ease, color 0.4s ease;
   }
 
   .header {
@@ -63,6 +64,7 @@
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     border-bottom: 1px solid rgba(255, 255, 255, 0.4);
+    transition: background 0.4s ease, border-color 0.4s ease;
   }
 
   .header-menu a {
@@ -72,6 +74,76 @@
 
   .header-menu li.current-menu-item a {
     color: #007bff !important;
+  }
+
+  .theme-toggle {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: none;
+    background: rgba(255, 255, 255, 0.8);
+    color: #1f2933;
+    font-size: 14px;
+    font-weight: 600;
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.15);
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease, transform 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    z-index: 1000;
+  }
+
+  .theme-toggle:hover {
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.95);
+  }
+
+  .search-box {
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    transition: background 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease;
+  }
+
+  .search-input {
+    color: #1f2933;
+  }
+
+  .search-input::placeholder {
+    color: rgba(51, 65, 85, 0.6);
+  }
+
+  .search-btn {
+    background: rgba(255, 255, 255, 0.85) !important;
+    border-radius: 12px !important;
+    transition: background 0.3s ease, transform 0.3s ease;
+  }
+
+  .search-btn:hover {
+    transform: translateY(-1px);
+  }
+
+  .nav-item {
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: 16px;
+    transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+    color: inherit;
+  }
+
+  .nav-item:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
+  }
+
+  .nav-item .nav-name {
+    color: #1f2933;
+    font-weight: 600;
+    letter-spacing: 0.3px;
   }
 
 
@@ -97,6 +169,82 @@
 
 
 
+  body.dark-mode {
+    background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.18), transparent 55%),
+      radial-gradient(circle at 80% 10%, rgba(165, 180, 252, 0.18), transparent 50%),
+      #0f172a !important;
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+    background-image: none !important;
+    color: #e2e8f0;
+  }
+
+  body.dark-mode .header {
+    background: rgba(15, 23, 42, 0.75);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  }
+
+  body.dark-mode .header-menu a {
+    color: #e2e8f0 !important;
+  }
+
+  body.dark-mode .header-menu li.current-menu-item a {
+    color: #38bdf8 !important;
+  }
+
+  body.dark-mode .theme-toggle {
+    background: rgba(15, 23, 42, 0.85);
+    color: #e2e8f0;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.45);
+  }
+
+  body.dark-mode .theme-toggle:hover {
+    background: rgba(15, 23, 42, 0.95);
+  }
+
+  body.dark-mode .search-box {
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    box-shadow: 0 12px 26px rgba(2, 6, 23, 0.45);
+  }
+
+  body.dark-mode .search-input {
+    color: #f8fafc;
+  }
+
+  body.dark-mode .search-input::placeholder {
+    color: rgba(226, 232, 240, 0.55);
+  }
+
+  body.dark-mode .search-btn {
+    background: rgba(56, 189, 248, 0.25) !important;
+  }
+
+  body.dark-mode .search-engine-list li {
+    background: rgba(15, 23, 42, 0.65);
+    color: #e2e8f0;
+  }
+
+  body.dark-mode .search-engine-list li:hover {
+    background: rgba(56, 189, 248, 0.2);
+    box-shadow: 0 0 8px rgba(56, 189, 248, 0.35);
+  }
+
+  body.dark-mode .nav-item {
+    background: rgba(15, 23, 42, 0.75);
+    box-shadow: 0 14px 28px rgba(2, 6, 23, 0.55);
+  }
+
+  body.dark-mode .nav-item:hover {
+    background: rgba(30, 41, 59, 0.9);
+    box-shadow: 0 18px 32px rgba(2, 6, 23, 0.65);
+  }
+
+  body.dark-mode .nav-item .nav-name {
+    color: #e2e8f0;
+  }
 </style>
 
 
@@ -112,6 +260,9 @@
 
 }-->
 <body style="background:url(images/beijing.png)no-repeat center fixed; background-position: center center; background-repeat: no-repeat; background-attachment: fixed; background-size:cover; text-align:center;  "  data-rsssl=1>
+  <button id="theme-toggle" class="theme-toggle" type="button" aria-label="切换黑夜模式" aria-pressed="false">
+    🌙 夜间模式
+  </button>
   <div class="header">
     <div class="container">
       <nav class="header-menu">
@@ -240,6 +391,46 @@
     </div>
   </div>
 
+
+  <script>
+    (function () {
+      var toggleButton = document.getElementById('theme-toggle');
+      if (!toggleButton) {
+        return;
+      }
+
+      var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var savedTheme = null;
+
+      try {
+        savedTheme = localStorage.getItem('theme');
+      } catch (error) {
+        savedTheme = null;
+      }
+
+      var shouldEnableDark = savedTheme === 'dark' || (!savedTheme && prefersDark);
+      if (shouldEnableDark) {
+        document.body.classList.add('dark-mode');
+      }
+
+      function updateButtonLabel(isDark) {
+        toggleButton.setAttribute('aria-pressed', isDark);
+        toggleButton.innerHTML = (isDark ? '☀️ 日间模式' : '🌙 夜间模式');
+      }
+
+      updateButtonLabel(document.body.classList.contains('dark-mode'));
+
+      toggleButton.addEventListener('click', function () {
+        var isDark = document.body.classList.toggle('dark-mode');
+        updateButtonLabel(isDark);
+        try {
+          localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        } catch (error) {
+          /* 忽略无法写入 localStorage 的情况 */
+        }
+      });
+    })();
+  </script>
 
   <script src="js/nav.ops-coffee.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a floating theme toggle button on the homepage to switch between light and dark appearances
- enhance homepage styling so navigation, search and headers respond smoothly to the active theme
- persist the selected theme across visits and respect the system color preference by default

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68ca3fb06fdc832082d2e2864638a9b8