### PR TITLE
Adjust icon wrapper sizing and restore background image

### DIFF
--- a/css/custom-theme.css
+++ b/css/custom-theme.css
@@ -35,6 +35,8 @@
   --search-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
   --search-engine-surface: rgba(255, 255, 255, 0.97);
   --search-engine-border: rgba(148, 163, 184, 0.24);
+  --nav-card-width: 220px;
+  --nav-card-height: 168px;
 }
 
 body.dark-mode {
@@ -43,7 +45,7 @@ body.dark-mode {
   --page-background-gradient: radial-gradient(circle at 15% 15%, rgba(56, 189, 248, 0.18), transparent 55%),
     radial-gradient(circle at 85% 12%, rgba(165, 180, 252, 0.16), transparent 50%),
     linear-gradient(180deg, rgba(15, 23, 42, 1) 0%, rgba(15, 23, 42, 0.95) 100%);
-  --page-background-image: none;
+  --page-background-image: url("../images/beijing.png");
   --page-text-color: #e2e8f0;
   --page-muted-color: rgba(203, 213, 225, 0.72);
   --header-background: rgba(15, 23, 42, 0.76);
@@ -374,9 +376,10 @@ select:focus-visible {
   color: var(--nav-name-color);
 }
 
+
 .nav-list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--nav-card-width), 1fr));
   gap: 24px;
   margin: 0;
   padding: 0;
@@ -389,6 +392,7 @@ select:focus-visible {
   width: auto;
   padding: 0;
   display: flex;
+  justify-content: center;
 }
 
 .nav-item {
@@ -405,8 +409,9 @@ select:focus-visible {
   box-shadow: var(--card-shadow);
   transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
   color: inherit;
-  height: 100%;
-  width: 100%;
+  width: var(--nav-card-width);
+  min-width: var(--nav-card-width);
+  min-height: var(--nav-card-height);
 }
 
 .nav-item:hover {

--- a/js/theme-settings.js
+++ b/js/theme-settings.js
@@ -75,7 +75,12 @@
   var heightOutput = document.getElementById('icon-height-value');
   var themeState = document.getElementById('theme-state');
   var themeIndicator = document.getElementById('settings-toggle-theme');
-  var navImages = Array.prototype.slice.call(document.querySelectorAll('.nav-img'));
+  var CARD_WIDTH_OFFSET = 172;
+  var CARD_HEIGHT_OFFSET = 120;
+  var MIN_CARD_WIDTH = 180;
+  var MAX_CARD_WIDTH = 320;
+  var MIN_CARD_HEIGHT = 140;
+  var MAX_CARD_HEIGHT = 260;
 
   var mediaQuery = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
 
@@ -127,10 +132,12 @@
     var heightValue = height + 'px';
     docEl.style.setProperty('--icon-wrapper-width', widthValue);
     docEl.style.setProperty('--icon-wrapper-height', heightValue);
-    navImages.forEach(function (icon) {
-      icon.style.width = widthValue;
-      icon.style.height = heightValue;
-    });
+
+    var cardWidth = Math.round(Math.min(MAX_CARD_WIDTH, Math.max(MIN_CARD_WIDTH, width + CARD_WIDTH_OFFSET)));
+    var cardHeight = Math.round(Math.min(MAX_CARD_HEIGHT, Math.max(MIN_CARD_HEIGHT, height + CARD_HEIGHT_OFFSET)));
+
+    docEl.style.setProperty('--nav-card-width', cardWidth + 'px');
+    docEl.style.setProperty('--nav-card-height', cardHeight + 'px');
   }
 
   function syncThemeButtons() {


### PR DESCRIPTION
## Summary
- update the navigation card sizing controls so the "icon wrapper" sliders resize the full button instead of only the inner frame
- expose new CSS variables that map icon dimensions to card width/height and ensure dark mode keeps the photographic background image

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68ca56cdce6c8320b3736368d37f7639