### PR TITLE
Adjust navigation layout and improve dark mode

### DIFF
--- a/css/custom-theme.css
+++ b/css/custom-theme.css
@@ -34,40 +34,40 @@
   --search-engine-border: rgba(148, 163, 184, 0.24);
   --search-box-height: 60px;
   --nav-card-width: 220px;
-  --nav-card-height: 168px;
+  --nav-card-height: 136px;
 }
 
 body.dark-mode {
   color-scheme: dark;
-  --page-background-color: #0f172a;
-  --page-background-image: url("../images/beijing.png");
-  --page-text-color: #1f2937;
-  --page-muted-color: rgba(55, 65, 81, 0.65);
-  --header-background: rgba(255, 255, 255, 0.82);
-  --header-border-color: rgba(148, 163, 184, 0.32);
-  --header-shadow: 0 16px 36px rgba(15, 23, 42, 0.22);
-  --card-background: rgba(255, 255, 255, 0.9);
-  --card-hover-background: rgba(255, 255, 255, 0.97);
-  --card-border-color: rgba(148, 163, 184, 0.28);
-  --card-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
-  --card-hover-shadow: 0 24px 52px rgba(15, 23, 42, 0.3);
-  --accent-color: #2563eb;
-  --accent-contrast-color: #ffffff;
-  --outline-color: rgba(37, 99, 235, 0.45);
-  --nav-name-color: #1f2937;
-  --settings-surface: rgba(255, 255, 255, 0.95);
-  --settings-border: rgba(148, 163, 184, 0.35);
-  --settings-shadow: 0 30px 56px rgba(15, 23, 42, 0.35);
-  --toggle-background: rgba(148, 163, 184, 0.35);
-  --toggle-active-background: rgba(37, 99, 235, 0.9);
-  --toggle-active-color: #ffffff;
-  --icon-wrapper-surface: transparent;
-  --icon-wrapper-hover-surface: transparent;
-  --search-surface: rgba(255, 255, 255, 0.92);
-  --search-border: rgba(148, 163, 184, 0.32);
-  --search-shadow: 0 28px 52px rgba(15, 23, 42, 0.28);
-  --search-engine-surface: rgba(255, 255, 255, 0.98);
-  --search-engine-border: rgba(148, 163, 184, 0.28);
+  --page-background-color: #0b1120;
+  --page-background-image: none;
+  --page-text-color: #e2e8f0;
+  --page-muted-color: rgba(148, 163, 184, 0.85);
+  --header-background: rgba(15, 23, 42, 0.8);
+  --header-border-color: rgba(51, 65, 85, 0.65);
+  --header-shadow: 0 18px 42px rgba(2, 6, 23, 0.7);
+  --card-background: rgba(15, 23, 42, 0.88);
+  --card-hover-background: rgba(30, 41, 59, 0.95);
+  --card-border-color: rgba(148, 163, 184, 0.2);
+  --card-shadow: 0 24px 50px rgba(2, 6, 23, 0.75);
+  --card-hover-shadow: 0 28px 60px rgba(2, 6, 23, 0.85);
+  --accent-color: #1d4ed8;
+  --accent-contrast-color: #f8fafc;
+  --outline-color: rgba(96, 165, 250, 0.6);
+  --nav-name-color: #f8fafc;
+  --settings-surface: rgba(15, 23, 42, 0.95);
+  --settings-border: rgba(51, 65, 85, 0.65);
+  --settings-shadow: 0 36px 70px rgba(2, 6, 23, 0.85);
+  --toggle-background: rgba(71, 85, 105, 0.65);
+  --toggle-active-background: rgba(59, 130, 246, 0.95);
+  --toggle-active-color: #f8fafc;
+  --icon-wrapper-surface: rgba(30, 41, 59, 0.8);
+  --icon-wrapper-hover-surface: rgba(46, 61, 89, 0.85);
+  --search-surface: rgba(15, 23, 42, 0.92);
+  --search-border: rgba(96, 165, 250, 0.35);
+  --search-shadow: 0 36px 60px rgba(2, 6, 23, 0.85);
+  --search-engine-surface: rgba(15, 23, 42, 0.98);
+  --search-engine-border: rgba(96, 165, 250, 0.28);
 }
 
 * {
@@ -205,9 +205,9 @@ select:focus-visible {
 
 .search {
   position: relative;
-  display: flex;
-  justify-content: center;
   width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
   padding: 0 16px;
 }
 
@@ -216,7 +216,7 @@ select:focus-visible {
   display: grid;
   grid-template-columns: var(--search-box-height) 1fr var(--search-box-height);
   align-items: stretch;
-  width: min(720px, 100%);
+  width: 100%;
   min-height: var(--search-box-height);
   padding: 0;
   border-radius: 20px;
@@ -325,8 +325,8 @@ select:focus-visible {
 }
 
 .search-icon {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   object-fit: contain;
 }
 
@@ -380,9 +380,9 @@ select:focus-visible {
 .search-engine {
   position: absolute;
   top: calc(100% + 14px);
-  left: 50%;
-  transform: translate(-50%, -8px);
-  width: min(720px, calc(100% - 32px));
+  left: 0;
+  transform: translateY(-8px);
+  width: min(360px, 100%);
   display: block;
   padding: 12px;
   border-radius: 16px;
@@ -399,7 +399,7 @@ select:focus-visible {
 .search-engine.is-open {
   opacity: 1;
   visibility: visible;
-  transform: translate(-50%, 0);
+  transform: translateY(0);
   pointer-events: auto;
 }
 
@@ -473,13 +473,14 @@ select:focus-visible {
 }
 
 .nav-item {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: var(--icon-wrapper-width) 1fr;
+  grid-template-rows: auto auto;
   align-items: center;
-  justify-content: flex-start;
-  text-align: center;
-  gap: 14px;
-  padding: 24px 22px;
+  column-gap: 16px;
+  row-gap: 6px;
+  text-align: left;
+  padding: 18px 20px;
   border-radius: 20px;
   background: var(--card-background);
   border: 1px solid var(--card-border-color);
@@ -499,19 +500,25 @@ select:focus-visible {
 }
 
 .nav-item .nav-name {
+  grid-column: 2;
   margin: 0;
   font-size: 16px;
   font-weight: 600;
   color: var(--nav-name-color);
+  align-self: center;
 }
 
 .nav-item p {
+  grid-column: 2;
   margin: 0;
   font-size: 14px;
+  line-height: 1.5;
   color: var(--page-muted-color);
+  align-self: start;
 }
 
 .nav-img {
+  grid-row: 1 / span 2;
   width: var(--icon-wrapper-width);
   height: var(--icon-wrapper-height);
   min-width: var(--icon-wrapper-width);
@@ -525,6 +532,7 @@ select:focus-visible {
   justify-content: center;
   margin: 0;
   align-self: center;
+  justify-self: start;
   float: none;
   flex-shrink: 0;
   transition: transform 0.25s ease, width 0.25s ease, height 0.25s ease;
@@ -549,6 +557,7 @@ select:focus-visible {
 
 .nav-cell > a.nav-item h2 {
   margin-bottom: 0;
+  grid-column: 1 / -1;
 }
 
 .settings {

--- a/js/theme-settings.js
+++ b/js/theme-settings.js
@@ -76,10 +76,10 @@
   var themeState = document.getElementById('theme-state');
   var themeIndicator = document.getElementById('settings-toggle-theme');
   var CARD_WIDTH_OFFSET = 172;
-  var CARD_HEIGHT_OFFSET = 120;
+  var CARD_HEIGHT_OFFSET = 72;
   var MIN_CARD_WIDTH = 180;
   var MAX_CARD_WIDTH = 320;
-  var MIN_CARD_HEIGHT = 140;
+  var MIN_CARD_HEIGHT = 120;
   var MAX_CARD_HEIGHT = 260;
 
   var mediaQuery = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;


### PR DESCRIPTION
## Summary
- align navigation icons with text on the right using a grid layout and reduce the minimum card height
- left-align the search engine selector, resize the icons for consistent alignment, and keep the dropdown anchored to the toggle
- refresh dark mode variables so backgrounds, surfaces, and controls switch to a cohesive dark palette
- adjust icon dimension calculations so the smaller default height reflects the slimmer navigation cards

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68ca676c8f08832082279f102aca22bf